### PR TITLE
Create initial DTOs with Mapper Profiles

### DIFF
--- a/JobHunt.sln
+++ b/JobHunt.sln
@@ -17,6 +17,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Persistence", "Source\Persi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Persistence.IntegrationTests", "Tests\Persistence.IntegrationTests\Persistence.IntegrationTests.csproj", "{43C55FD2-1F8A-4F6C-8567-840C34A8E16F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Application.UnitTests", "Tests\Application.UnitTests\Application.UnitTests.csproj", "{00F597A3-1A29-4538-9AEC-8EE33DB5B2F4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,6 +45,10 @@ Global
 		{43C55FD2-1F8A-4F6C-8567-840C34A8E16F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{43C55FD2-1F8A-4F6C-8567-840C34A8E16F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{43C55FD2-1F8A-4F6C-8567-840C34A8E16F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{00F597A3-1A29-4538-9AEC-8EE33DB5B2F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{00F597A3-1A29-4538-9AEC-8EE33DB5B2F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{00F597A3-1A29-4538-9AEC-8EE33DB5B2F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{00F597A3-1A29-4538-9AEC-8EE33DB5B2F4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,6 +59,7 @@ Global
 		{EF6F1367-415E-4070-A474-7D3F01A12CB5} = {1578D36A-7874-45AC-A13E-AC4EEE2183B7}
 		{26C7A391-039E-4F43-A109-82DE66B8A5ED} = {1578D36A-7874-45AC-A13E-AC4EEE2183B7}
 		{43C55FD2-1F8A-4F6C-8567-840C34A8E16F} = {96302832-D477-445B-9649-9BBDC1D4E076}
+		{00F597A3-1A29-4538-9AEC-8EE33DB5B2F4} = {96302832-D477-445B-9649-9BBDC1D4E076}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {72B04D1C-CC79-432C-A5CA-A182070ED41D}

--- a/Source/API/Controllers/JobsController.cs
+++ b/Source/API/Controllers/JobsController.cs
@@ -1,9 +1,9 @@
 ﻿using Application.Commands;
 using Application.Queries;
-using Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
+using Application.DTOs;
 
 namespace API.Controllers
 {
@@ -35,11 +35,11 @@ namespace API.Controllers
         }
 
         [HttpPost]
-        public async Task<IActionResult> Add([FromBody] Job job)
+        public async Task<IActionResult> Add([FromBody] CreateJobRequest newJobRequest)
         {
-            var command = new CreateJobCommand(job);
-            await _mediator.Send(command);
-            return Created("", job);
+            var command = new CreateJobCommand(newJobRequest);
+            var result = await _mediator.Send(command);
+            return result != null ? Created("", result) : UnprocessableEntity();
         }
     }
 }

--- a/Source/API/Program.cs
+++ b/Source/API/Program.cs
@@ -1,9 +1,11 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
 namespace API
 {
+    [ExcludeFromCodeCoverage]
     public class Program
     {
         public static void Main(string[] args)

--- a/Source/API/Startup.cs
+++ b/Source/API/Startup.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Application;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -9,6 +10,7 @@ using Persistence;
 
 namespace API
 {
+    [ExcludeFromCodeCoverage]
     public class Startup
     {
         public Startup(IConfiguration configuration)

--- a/Source/Application/Application.csproj
+++ b/Source/Application/Application.csproj
@@ -1,10 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="10.1.1" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
     <PackageReference Include="FluentValidation" Version="8.5.0-preview5" />
     <PackageReference Include="MediatR" Version="7.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />

--- a/Source/Application/Commands/CreateJobCommand.cs
+++ b/Source/Application/Commands/CreateJobCommand.cs
@@ -4,37 +4,44 @@ using MediatR;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Application.DTOs;
+using AutoMapper;
 
 namespace Application.Commands
 {
-    public class CreateJobCommand : IRequest<bool>
+    public class CreateJobCommand : IRequest<string>
     {
-        public Job Job { get; }
+        private CreateJobRequest NewJobRequest { get; }
 
-        public CreateJobCommand(Job job)
+        public CreateJobCommand(CreateJobRequest newJobRequest)
         {
-            Job = job;
+            NewJobRequest = newJobRequest;
         }
 
-        public class CreateJobCommandHandler : IRequestHandler<CreateJobCommand, bool>
+        public class CreateJobCommandHandler : IRequestHandler<CreateJobCommand, string>
         {
-            private IUnitOfWork _unitOfWork;
+            private readonly IUnitOfWork _unitOfWork;
+            private readonly IMapper _mapper;
 
-            public CreateJobCommandHandler(IUnitOfWork unitOfWork)
+            public CreateJobCommandHandler(IUnitOfWork unitOfWork, IMapper mapper)
             {
                 _unitOfWork = unitOfWork;
+                _mapper = mapper;
             }
 
-            public async Task<bool> Handle(CreateJobCommand request, CancellationToken cancellationToken)
+            public async Task<string> Handle(CreateJobCommand request, CancellationToken cancellationToken)
             {
-                GenerateId(request.Job);
-                await _unitOfWork.Jobs.AddAsync(request.Job);
-                return true;
-            }
-
-            private void GenerateId(Job job)
-            {
-                job.Id = Guid.NewGuid().ToString();
+                try
+                {
+                    Job job = _mapper.Map<Job>(request.NewJobRequest);
+                    await _unitOfWork.Jobs.AddAsync(job);
+                    return job.Id;
+                }
+                catch(Exception e)
+                {
+                    Console.WriteLine(e.Message);
+                    return null;
+                }
             }
         }
     }

--- a/Source/Application/DTOs/CreateJobRequest.cs
+++ b/Source/Application/DTOs/CreateJobRequest.cs
@@ -1,0 +1,21 @@
+using System;
+using Domain.Entities;
+
+namespace Application.DTOs
+{
+    public class CreateJobRequest
+    {
+        public string JobTitle { get; set; }
+        public string Employer { get; set; }
+        public string City { get; set; }
+        public string State { get; set; }
+        public string Status { get; set; }
+        public decimal? MinimumSalary { get; set; }
+        public decimal? MaximumSalary { get; set; }
+        public DateTime? DateSubmitted { get; set; }
+        public DateTime? DateLastUpdated { get; set; }
+        
+        public Amenity Amenities { get; set; }
+        public TechnologyStack TechnologyStack { get; set; }
+    }
+}

--- a/Source/Application/DTOs/ListResponse.cs
+++ b/Source/Application/DTOs/ListResponse.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace Application.DTOs
+{
+    public class ListResponse<T>
+    {
+        public int Count { get; set; }
+        public List<T> Data { get; set; }
+    }
+}

--- a/Source/Application/DependencyInjection.cs
+++ b/Source/Application/DependencyInjection.cs
@@ -8,6 +8,7 @@ namespace Application
     {
         public static IServiceCollection AddApplication(this IServiceCollection services)
         {
+            services.AddAutoMapper(Assembly.GetExecutingAssembly());
             services.AddMediatR(Assembly.GetExecutingAssembly());
             return services;
         }

--- a/Source/Application/DependencyInjection.cs
+++ b/Source/Application/DependencyInjection.cs
@@ -1,9 +1,11 @@
-﻿using MediatR;
+﻿using System.Diagnostics.CodeAnalysis;
+using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using System.Reflection;
 
 namespace Application
 {
+    [ExcludeFromCodeCoverage]
     public static class DependencyInjection
     {
         public static IServiceCollection AddApplication(this IServiceCollection services)

--- a/Source/Application/Mappings/JobProfile.cs
+++ b/Source/Application/Mappings/JobProfile.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using Application.DTOs;
+using AutoMapper;
+using Domain.Entities;
+
+namespace Application.Mappings
+{
+    public class JobProfile : Profile
+    {
+        public JobProfile()
+        {
+            CreateMap<CreateJobRequest, Job>()
+                .ForMember(dest => dest.Id, src => src.MapFrom(job => Guid.NewGuid().ToString()))
+                .ForMember(dest => dest.DateSubmitted, src => src.MapFrom(job => job.DateSubmitted ?? DateTime.Now))
+                .AfterMap((src, dest) =>
+                {
+                    if(src.DateLastUpdated == null)
+                        dest.DateLastUpdated = dest.DateSubmitted;
+                });
+
+            CreateMap<List<Job>, ListResponse<Job>>()
+                .ForMember(dest => dest.Count, src => src.MapFrom(list => list.Count))
+                .ForMember(dest => dest.Data, src => src.MapFrom(list => list));
+        }
+    }
+}

--- a/Source/Application/Queries/GetAllJobsQuery.cs
+++ b/Source/Application/Queries/GetAllJobsQuery.cs
@@ -4,24 +4,29 @@ using MediatR;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Application.DTOs;
+using AutoMapper;
 
 namespace Application.Queries
 {
-    public class GetAllJobsQuery : IRequest<IEnumerable<Job>>
+    public class GetAllJobsQuery : IRequest<ListResponse<Job>>
     {
-        public class GetAllJobsQueryHandler : IRequestHandler<GetAllJobsQuery, IEnumerable<Job>>
+        public class GetAllJobsQueryHandler : IRequestHandler<GetAllJobsQuery, ListResponse<Job>>
         {
             private readonly IUnitOfWork _unitOfWork;
+            private readonly IMapper _mapper;
 
-            public GetAllJobsQueryHandler(IUnitOfWork unitOfWork)
+            public GetAllJobsQueryHandler(IUnitOfWork unitOfWork, IMapper mapper)
             {
                 _unitOfWork = unitOfWork;
+                _mapper = mapper;
             }
 
-            public async Task<IEnumerable<Job>> Handle(GetAllJobsQuery request, CancellationToken cancellationToken)
+            public async Task<ListResponse<Job>> Handle(GetAllJobsQuery request, CancellationToken cancellationToken)
             {
-                var jobs = await _unitOfWork.Jobs.GetAllAsync();
-                return jobs;
+                IEnumerable<Job> jobs = await _unitOfWork.Jobs.GetAllAsync();
+                ListResponse<Job> response = _mapper.Map<ListResponse<Job>>(jobs);
+                return response;
             }
         }
     }

--- a/Source/Application/Queries/GetJobByIdQuery.cs
+++ b/Source/Application/Queries/GetJobByIdQuery.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Application.Queries
 {
-    public class GetJobByIdQuery : IRequest<object>
+    public class GetJobByIdQuery : IRequest<Job>
     {
         public string Id { get; }
 
@@ -15,7 +15,7 @@ namespace Application.Queries
             Id = id;
         }
 
-        public class GetJobByIdQueryHandler : IRequestHandler<GetJobByIdQuery, object>
+        public class GetJobByIdQueryHandler : IRequestHandler<GetJobByIdQuery, Job>
         {
             private readonly IUnitOfWork _unitOfWork;
 
@@ -24,7 +24,7 @@ namespace Application.Queries
                 _unitOfWork = unitOfWork;
             }
 
-            public async Task<object> Handle(GetJobByIdQuery request, CancellationToken cancellationToken)
+            public async Task<Job> Handle(GetJobByIdQuery request, CancellationToken cancellationToken)
             {
                 Job job = await _unitOfWork.Jobs.GetAsync(request.Id);
                 return job;

--- a/Source/Domain/Domain.csproj
+++ b/Source/Domain/Domain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Persistence/DependencyInjection.cs
+++ b/Source/Persistence/DependencyInjection.cs
@@ -1,10 +1,12 @@
-﻿using Amazon.DynamoDBv2;
+﻿using System.Diagnostics.CodeAnalysis;
+using Amazon.DynamoDBv2;
 using Application.Common.Interfaces;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Persistence
 {
+    [ExcludeFromCodeCoverage]
     public static class DependencyInjection
     {
         public static IServiceCollection AddPersistence(this IServiceCollection services, IConfiguration configuration)

--- a/Source/Persistence/Persistence.csproj
+++ b/Source/Persistence/Persistence.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/Application.UnitTests/Application.UnitTests.csproj
+++ b/Tests/Application.UnitTests/Application.UnitTests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net5.0</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="1.3.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\Source\Application\Application.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Tests/Application.UnitTests/DTOs/CreateJobRequestTests.cs
+++ b/Tests/Application.UnitTests/DTOs/CreateJobRequestTests.cs
@@ -1,0 +1,56 @@
+using System;
+using Application.DTOs;
+using Domain.Entities;
+using Xunit;
+
+namespace Application.UnitTests.DTOs
+{
+    public class CreateJobRequestTests
+    {
+        [Fact]
+        public void GetValuesShouldReturnSetValues()
+        {
+            // Arrange
+            string jobTitle = "JobTitle";
+            string employer = "Employer";
+            string city = "City";
+            string state = "State";
+            string status = "Status";
+            decimal minimumSalary = decimal.MinValue;
+            decimal maximumSalary = decimal.MaxValue;
+            DateTime dateSubmitted = DateTime.MinValue;
+            DateTime dateLastUpdated = DateTime.MaxValue;
+
+            Amenity amenity = new Amenity();
+            TechnologyStack technologyStack = new TechnologyStack();
+
+            CreateJobRequest sut = new CreateJobRequest();
+            
+            // Act
+            sut.JobTitle = jobTitle;
+            sut.Employer = employer;
+            sut.City = city;
+            sut.State = state;
+            sut.Status = status;
+            sut.MinimumSalary = minimumSalary;
+            sut.MaximumSalary = maximumSalary;
+            sut.DateSubmitted = dateSubmitted;
+            sut.DateLastUpdated = dateLastUpdated;
+            sut.Amenities = amenity;
+            sut.TechnologyStack = technologyStack;
+
+            // Assert
+            Assert.Equal(jobTitle, sut.JobTitle);
+            Assert.Equal(employer, sut.Employer);
+            Assert.Equal(city, sut.City);
+            Assert.Equal(state, sut.State);
+            Assert.Equal(status, sut.Status);
+            Assert.Equal(minimumSalary, sut.MinimumSalary);
+            Assert.Equal(maximumSalary, sut.MaximumSalary);
+            Assert.Equal(dateSubmitted, sut.DateSubmitted);
+            Assert.Equal(dateLastUpdated, sut.DateLastUpdated);
+            Assert.Equal(amenity, sut.Amenities);
+            Assert.Equal(technologyStack, sut.TechnologyStack);
+        }
+    }
+}

--- a/Tests/Application.UnitTests/DTOs/ListResponseTests.cs
+++ b/Tests/Application.UnitTests/DTOs/ListResponseTests.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using Application.DTOs;
+using Xunit;
+
+namespace Application.UnitTests.DTOs
+{
+    public class ListResponseTests
+    {
+        [Fact]
+        public void GetValuesShouldReturnSetValues()
+        {
+            // Arrange
+            int count = 5;
+            List<int> data = new List<int>() {1, 2, 3, 4, 5};
+            
+            // Act
+            ListResponse<int> sut = new ListResponse<int>()
+            {
+                Count = count,
+                Data = data
+            };
+            
+            // Assert
+            Assert.Equal(count, sut.Count);
+            Assert.Equal(data, sut.Data);
+        }
+    }
+}

--- a/Tests/Application.UnitTests/Mappings/JobProfileTests.cs
+++ b/Tests/Application.UnitTests/Mappings/JobProfileTests.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using Application.DTOs;
+using Application.Mappings;
+using AutoMapper;
+using Domain.Entities;
+using Xunit;
+
+namespace Application.UnitTests.Mappings
+{
+    public class JobProfileTests
+    {
+        private readonly IMapper _mapper;
+        private readonly IConfigurationProvider _configuration;
+        
+        public JobProfileTests()
+        {
+            _configuration = new MapperConfiguration(c => c.AddProfile<JobProfile>());
+            _mapper = new Mapper(_configuration);
+        }
+        
+        [Fact]
+        public void ShouldHaveValidConfiguration()
+        {
+            _configuration.AssertConfigurationIsValid();
+        }
+
+        [Fact]
+        public void ShouldMapCreateJobRequestToJob()
+        {
+            // Arrange
+            CreateJobRequest jobRequest = new CreateJobRequest();
+            
+            // Act
+            Job job = _mapper.Map<Job>(jobRequest);
+            
+            // Assert
+            Assert.NotNull(job);
+            Assert.IsType<Job>(job);
+        }
+
+        [Fact]
+        public void ShouldMapJobListToJobListResponse()
+        {
+            // Arrange
+            List<Job> jobs = new List<Job>();
+            
+            // Act
+            ListResponse<Job> response = _mapper.Map<ListResponse<Job>>(jobs);
+            
+            // Assert
+            Assert.NotNull(response);
+            Assert.NotNull(response.Data);
+            Assert.Equal(0, response.Count);
+        }
+    }
+}


### PR DESCRIPTION
Create Data Transfer Objects for incoming requests/outgoing responses to decouple the entities from the API allowing each endpoint to control the structure/data the consumer will receive.

The DTOs will need to be mapped from and to the Domain objects. It would be viable to use a mapper library like AutoMapper or Mapster.

DTOs should be contained in a folder called DTOs
Mapping logic should be contained in a folder called Mappings. 
These folders should be inside the Application Layer.

- [x] Select a mapping library
- [x] Create DTO objects based on API's complex requests and responses
- [x] Create Mappings for DTOs from/to Entity objects
- [x] Create Unit Tests for the Mapping Logic

Closes #2 